### PR TITLE
fix(pikpak): rethrow CancellationException in testPikPakLogin

### DIFF
--- a/torrent/pikpak/src/commonMain/kotlin/me/him188/ani/torrent/pikpak/PikPakConnectionTest.kt
+++ b/torrent/pikpak/src/commonMain/kotlin/me/him188/ani/torrent/pikpak/PikPakConnectionTest.kt
@@ -4,6 +4,7 @@ import io.github.nihildigit.pikpak.PikPakClient
 import io.github.nihildigit.pikpak.Session
 import io.github.nihildigit.pikpak.SessionStore
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CancellationException
 
 /**
  * Throwaway login probe: builds a [PikPakClient] with the given credentials and
@@ -29,6 +30,8 @@ suspend fun testPikPakLogin(
     return try {
         client.login()
         true
+    } catch (e: CancellationException) {
+        throw e
     } catch (_: Throwable) {
         false
     } finally {


### PR DESCRIPTION
The probe's catch (Throwable) was swallowing CancellationException, so
coroutine cancellation from the settings connection-test job, view-model
scope, or Ktor/PikPak login path was being converted into a `false`
return — making cancelled probes look like normal failed logins and
breaking structured cancellation up the call chain.

Catch CancellationException explicitly and rethrow before the generic
Throwable branch handles real auth/network failures.

Reported in upstream PR review (StageGuard, Copilot).