### PR TITLE
Fix auto-next-episode incorrectly triggering again when first media source fails after switching (#2987)

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
@@ -60,16 +60,20 @@ class SwitchNextEpisodeExtension(
 
     private suspend fun impl(session: EpisodeSession): Nothing {
         val player = context.player
-        player.playbackState.collect { playback ->
-            val closeToEnd = player.mediaProperties.value.let { prop ->
-                prop != null && prop.durationMillis > 0L && prop.durationMillis - player.currentPositionMillis.value < 5000
-            }
+        var previous: PlaybackState? = null
+        player.playbackState.collect { current ->
+            if (previous == PlaybackState.PLAYING && current == PlaybackState.FINISHED) {
+                val closeToEnd = player.mediaProperties.value.let { prop ->
+                    prop != null && prop.durationMillis > 0L && prop.durationMillis - player.currentPositionMillis.value < 5000
+                }
 
-            if (playback == PlaybackState.FINISHED && closeToEnd) {
-                val nextEpisode = getNextEpisode(session.episodeId)
-                logger.info("播放完毕，切换下一集 $nextEpisode")
-                context.switchEpisode(nextEpisode ?: return@collect)
+                if (closeToEnd) {
+                    val nextEpisode = getNextEpisode(session.episodeId)
+                    logger.info("播放完毕，切换下一集 $nextEpisode")
+                    context.switchEpisode(nextEpisode ?: return@collect)
+                }
             }
+            previous = current
         }
     }
 

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
@@ -100,7 +100,7 @@ class EpisodePlayerTestSuite(
 fun TestScope.createExceptionCapturingSupervisorScope(parentScope: CoroutineScope = backgroundScope): Pair<CoroutineScope, CompletableDeferred<Throwable>> {
     val backgroundException = CompletableDeferred<Throwable>()
     val scope = CoroutineScope(
-        SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineExceptionHandler { _, throwable ->
+        (parentScope.coroutineContext.minusKey(Job)) + SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineExceptionHandler { _, throwable ->
             backgroundException.complete(throwable)
         },
     )

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/SwitchNextEpisodeExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/SwitchNextEpisodeExtensionTest.kt
@@ -30,12 +30,17 @@ import me.him188.ani.app.domain.episode.createExceptionCapturingSupervisorScope
 import me.him188.ani.app.domain.episode.getCurrentEpisodeId
 import me.him188.ani.app.domain.episode.mediaSelectorFlow
 import me.him188.ani.app.domain.media.TestMediaList
+import me.him188.ani.app.domain.media.player.data.MediaDataProvider
+import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
 import me.him188.ani.app.domain.media.resolver.MediaResolver
 import me.him188.ani.app.domain.media.resolver.TestUniversalMediaResolver
+import me.him188.ani.app.domain.media.resolver.UnsupportedMediaException
 import me.him188.ani.app.domain.player.ExtensionException
 import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
+import me.him188.ani.datasources.api.Media
 import me.him188.ani.utils.coroutines.childScope
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.metadata.MediaProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -63,12 +68,15 @@ class SwitchNextEpisodeExtensionTest : AbstractPlayerExtensionTest() {
         }
     }
 
-    private fun TestScope.createCase(getNextEpisode: suspend (currentEpisodeId: Int) -> Int?) = run {
+    private fun TestScope.createCase(
+        getNextEpisode: suspend (currentEpisodeId: Int) -> Int?,
+        resolver: MediaResolver = TestUniversalMediaResolver,
+    ) = run {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val testScope = this.childScope()
         val suite = EpisodePlayerTestSuite(this, testScope)
         suite.enableAutoPlayNext()
-        suite.registerComponent<MediaResolver> { TestUniversalMediaResolver }
+        suite.registerComponent<MediaResolver> { resolver }
 
         val state = suite.createState(
             listOf(
@@ -208,5 +216,61 @@ class SwitchNextEpisodeExtensionTest : AbstractPlayerExtensionTest() {
             assertIs<RepositoryNetworkException>(cause)
         }
         scope.cancel()
+    }
+
+    @Test
+    fun `does not switch next episode when playback never started after switching`() = runTest {
+        var getNextEpisodeCalled = 0
+        val failingResolver = object : MediaResolver {
+            override fun supports(media: Media): Boolean = true
+            override suspend fun resolve(media: Media, episode: EpisodeMetadata): MediaDataProvider<*> =
+                throw UnsupportedMediaException(media)
+        }
+        val (testScope, suite, state) =
+            createCase(
+                getNextEpisode = {
+                    getNextEpisodeCalled++
+                    1000
+                },
+                resolver = failingResolver,
+            )
+
+        loadSelectedMedia(suite, state)
+
+        assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
+        assertEquals(0, getNextEpisodeCalled)
+
+        // 播到最尾部了，触发自动切集
+        suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
+        suite.player.playbackState.value = PlaybackState.PLAYING
+        advanceUntilIdle()
+        suite.player.playbackState.value = PlaybackState.FINISHED
+        advanceUntilIdle()
+
+        // Verify switched to next episode (1000)
+        assertEquals(1000, state.getCurrentEpisodeId())
+        assertEquals(1, getNextEpisodeCalled)
+
+        // Trigger media selection for new episode to load (and fail) and broadcast MediaLoadedEvent
+        state.mediaSelectorFlow.filterNotNull().first().select(TestMediaList[0])
+        advanceUntilIdle()
+
+        // Simulate production player state where mediaProperties is not cleared
+        // after stopPlayback and playbackState remains FINISHED.
+        suite.player.mediaProperties.value = MediaProperties(
+            durationMillis = 100_000,
+        )
+        suite.player.seekTo(100_000)
+        // Toggle playbackState to trigger a FINISHED evaluation while hasStartedPlaying is false
+        suite.player.playbackState.value = PlaybackState.CREATED
+        advanceUntilIdle()
+        suite.player.playbackState.value = PlaybackState.FINISHED
+        advanceUntilIdle()
+
+        // Verify does NOT switch again
+        assertEquals(1000, state.getCurrentEpisodeId())
+        assertEquals(1, getNextEpisodeCalled)
+
+        testScope.cancel()
     }
 }

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -501,6 +501,15 @@
     <string name="settings_debug_logout">退出登录</string>
     <string name="settings_debug_logged_out">已退出登录</string>
     <string name="settings_tab_account">账号</string>
+
+    <!-- Account Popup -->
+    <string name="settings_account_popup_not_logged_in">未登录</string>
+    <string name="settings_account_popup_edit_profile">编辑个人资料</string>
+    <string name="settings_account_popup_login_register">登录 / 注册</string>
+    <string name="settings_account_popup_logout">退出登录</string>
+    <string name="settings_account_popup_logout_confirm">确定要退出登录吗？</string>
+    <string name="settings_account_popup_logout_button">退出登录</string>
+    <string name="settings_account_popup_cancel">取消</string>
 </resources>
 
 <!--@formatter:on-->

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -479,7 +479,19 @@
     <string name="settings_media_auto_cache_recent_only">僅緩存最近看過的番劇</string>
     <string name="settings_media_auto_cache_count">緩存數量</string>
     <string name="settings_media_auto_cache_count_description">當前設置: 僅緩存最近看過的 %d 部番劇</string>
-    <string name="settings_media_auto_cache_manage">管理已緩存的劇集</string><string name="settings_debug_logout">登出</string><string name="settings_debug_logged_out">已登出</string><string name="settings_tab_account">賬戶</string>
+    <string name="settings_media_auto_cache_manage">管理已緩存的劇集</string>
+    <string name="settings_debug_logout">登出</string>
+    <string name="settings_debug_logged_out">已登出</string>
+    <string name="settings_tab_account">賬戶</string>
+
+    <!-- Account Popup -->
+    <string name="settings_account_popup_not_logged_in">未登入</string>
+    <string name="settings_account_popup_edit_profile">編輯個人資料</string>
+    <string name="settings_account_popup_login_register">登入 / 註冊</string>
+    <string name="settings_account_popup_logout">登出</string>
+    <string name="settings_account_popup_logout_confirm">確定要登出嗎？</string>
+    <string name="settings_account_popup_logout_button">登出</string>
+    <string name="settings_account_popup_cancel">取消</string>
 
     <!-- Version Expired Overlay -->
     <string name="settings_update_version_expired_title">版本過期</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -479,7 +479,19 @@
     <string name="settings_media_auto_cache_recent_only">僅快取最近看過的番劇</string>
     <string name="settings_media_auto_cache_count">快取數量</string>
     <string name="settings_media_auto_cache_count_description">目前設定: 僅快取最近看過的 %d 部番劇</string>
-    <string name="settings_media_auto_cache_manage">管理已快取的劇集</string><string name="settings_debug_logout">登出</string><string name="settings_debug_logged_out">已登出</string><string name="settings_tab_account">賬戶</string>
+    <string name="settings_media_auto_cache_manage">管理已快取的劇集</string>
+    <string name="settings_debug_logout">登出</string>
+    <string name="settings_debug_logged_out">已登出</string>
+    <string name="settings_tab_account">賬戶</string>
+
+    <!-- Account Popup -->
+    <string name="settings_account_popup_not_logged_in">未登入</string>
+    <string name="settings_account_popup_edit_profile">編輯個人資料</string>
+    <string name="settings_account_popup_login_register">登入 / 註冊</string>
+    <string name="settings_account_popup_logout">登出</string>
+    <string name="settings_account_popup_logout_confirm">確定要登出嗎？</string>
+    <string name="settings_account_popup_logout_button">登出</string>
+    <string name="settings_account_popup_cancel">取消</string>
 </resources>
 
 <!--@formatter:on-->

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -463,6 +463,15 @@
     <string name="settings_debug_logout">Logout</string>
     <string name="settings_debug_logged_out">Logged out</string>
     <string name="settings_tab_account">Account</string>
+
+    <!-- Account Popup -->
+    <string name="settings_account_popup_not_logged_in">Not logged in</string>
+    <string name="settings_account_popup_edit_profile">Edit profile</string>
+    <string name="settings_account_popup_login_register">Login / Register</string>
+    <string name="settings_account_popup_logout">Logout</string>
+    <string name="settings_account_popup_logout_confirm">Are you sure you want to logout?</string>
+    <string name="settings_account_popup_logout_button">Logout</string>
+    <string name="settings_account_popup_cancel">Cancel</string>
 </resources>
 
 <!--@formatter:on-->

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/account/ProfilePopup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/account/ProfilePopup.kt
@@ -48,6 +48,11 @@ import me.him188.ani.app.ui.foundation.layout.currentWindowAdaptiveInfo1
 import me.him188.ani.app.ui.foundation.layout.isHeightAtLeastMedium
 import me.him188.ani.app.ui.foundation.layout.isWidthAtLeastMedium
 import me.him188.ani.app.ui.foundation.rememberAsyncHandler
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.settings_account_popup_cancel
+import me.him188.ani.app.ui.lang.settings_account_popup_logout_button
+import me.him188.ani.app.ui.lang.settings_account_popup_logout_confirm
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * 在右上角显示的个人信息弹窗
@@ -163,15 +168,15 @@ fun AccountLogoutDialog(
     AlertDialog(
         onCancel,
         icon = { Icon(Icons.AutoMirrored.Outlined.Logout, null) },
-        text = { Text("确定要退出登录吗?") },
+        text = { Text(stringResource(Lang.settings_account_popup_logout_confirm)) },
         confirmButton = {
             TextButton(onConfirm, enabled = confirmEnabled) {
-                Text("退出登录", color = MaterialTheme.colorScheme.error)
+                Text(stringResource(Lang.settings_account_popup_logout_button), color = MaterialTheme.colorScheme.error)
             }
         },
         dismissButton = {
             TextButton(onCancel) {
-                Text("取消")
+                Text(stringResource(Lang.settings_account_popup_cancel))
             }
         },
     )

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/account/ProfilePopupLayout.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/account/ProfilePopupLayout.kt
@@ -51,9 +51,16 @@ import me.him188.ani.app.ui.foundation.avatar.AvatarImage
 import me.him188.ani.app.ui.foundation.interaction.hoverable
 import me.him188.ani.app.ui.foundation.text.ProvideContentColor
 import me.him188.ani.app.ui.foundation.widgets.HeroIcon
+import me.him188.ani.app.ui.lang.Lang
+import me.him188.ani.app.ui.lang.settings
+import me.him188.ani.app.ui.lang.settings_account_popup_edit_profile
+import me.him188.ani.app.ui.lang.settings_account_popup_login_register
+import me.him188.ani.app.ui.lang.settings_account_popup_logout
+import me.him188.ani.app.ui.lang.settings_account_popup_not_logged_in
 import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.components.TextItem
 import me.him188.ani.app.ui.user.SelfInfoUiState
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun ProfilePopupLayout(
@@ -88,7 +95,7 @@ internal fun ProfilePopupLayout(
         val showEmail = false
 
         Text(
-            if (isLogin) title else "未登录",
+            if (isLogin) title else stringResource(Lang.settings_account_popup_not_logged_in),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             modifier = Modifier
@@ -128,14 +135,14 @@ internal fun ProfilePopupLayout(
                         icon = { Icon(Icons.Outlined.Edit, contentDescription = "Edit profile settings") },
                         onClick = onClickEditProfile,
                     ) {
-                        Text("编辑个人资料")
+                        Text(stringResource(Lang.settings_account_popup_edit_profile))
                     }
                 } else {
                     TextItem(
                         icon = { Icon(Icons.AutoMirrored.Outlined.Login, contentDescription = "Login") },
                         onClick = onClickLogin,
                     ) {
-                        Text("登录 / 注册")
+                        Text(stringResource(Lang.settings_account_popup_login_register))
                     }
                 }
 
@@ -143,7 +150,7 @@ internal fun ProfilePopupLayout(
                     icon = { Icon(Icons.Outlined.Settings, contentDescription = "Settings") },
                     onClick = onClickSettings,
                 ) {
-                    Text("设置")
+                    Text(stringResource(Lang.settings))
                 }
 
                 if (isLogin) {
@@ -159,7 +166,7 @@ internal fun ProfilePopupLayout(
                         onClick = onClickLogout,
                     ) {
                         ProvideContentColor(MaterialTheme.colorScheme.error) {
-                            Text("退出登录")
+                            Text(stringResource(Lang.settings_account_popup_logout))
                         }
                     }
                 }


### PR DESCRIPTION
* fix(player): prevent auto-switching to next episode when playback never started

* fix(player): refine episode switching logic based on playback state transitions